### PR TITLE
Release v0.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         package-release: ['lowest', 'source', 'dist']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Roelofr\PostcodeApi\Exceptions\CacheClearException` in case cache clearing
   goes south.
 
+## Fixed
+ - Tests no longer make API calls, but use mocked responses instead
+
 ## [0.2.0] - 2020-01-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `postcode:clear-cache` command, to remove cached postcodes on a tagged cache
+- `Roelofr\PostcodeApi\Contracts\CacheServiceContract` for allowing you to skip
+  writing cache-clearing logic if you don't need to.
+- `Roelofr\PostcodeApi\Exceptions\CacheClearException` in case cache clearing
+  goes south.
+
 ## [0.2.0] - 2020-01-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2020-01-23
+
 ### Added
 - `postcode:clear-cache` command, to remove cached postcodes on a tagged cache
 - `Roelofr\PostcodeApi\Contracts\CacheServiceContract` for allowing you to skip
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 First commit.
 
-[Unreleased]: https://github.com/roelofr/postcode-api/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/roelofr/postcode-api/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/roelofr/postcode-api/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/roelofr/postcode-api/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/roelofr/postcode-api/releases/tag/v0.1.0

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     },
     "require-dev": {
         "minimaxir/big-list-of-naughty-strings": "^1.0",
+        "nesbot/carbon": "^2.28",
         "orchestra/testbench": "^3.1 | ^4.0",
-        "squizlabs/php_codesniffer": "^3.2",
         "phpunit/phpunit": "^7.0",
-        "nesbot/carbon": "^2.28"
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "scripts": {
         "lint": "phpcs",

--- a/src/Commands/ClearPostcodeCacheCommand.php
+++ b/src/Commands/ClearPostcodeCacheCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Roelofr\PostcodeApi\Commands;
+
+use App\Jobs\SendTo2Solar;
+use App\Models\Lead;
+use Illuminate\Console\Command;
+use Roelofr\PostcodeApi\Exceptions\CacheClearException;
+use Roelofr\PostcodeApi\Services\PostcodeApiService;
+
+class ClearPostcodeCacheCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'postcode:clear-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Removes cached postcodes';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(PostcodeApiService $service)
+    {
+        try {
+            // Try to clear the cache
+            $service->clearCache();
+
+            // Pass if OK
+            return true;
+        } catch (CacheClearException $exception) {
+            // Report error
+            $this->line("Failed to clear cache: <info>{$exception->getMessage()}</>");
+
+            // Fail
+            return false;
+        }
+    }
+}

--- a/src/Contracts/CachedServiceContract.php
+++ b/src/Contracts/CachedServiceContract.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roelofr\PostcodeApi\Contracts;
+
+use Roelofr\PostcodeApi\Models\AddressInformation;
+
+/**
+ * Handles support for caches that can be cleared.
+ *
+ * @license MIT
+ */
+interface CachedServiceContract
+{
+    /**
+     * Clears cached postcodes, causing all locally stored results to be re-retrieved.
+     *
+     * @throws Roelofr\PostcodeApi\Exceptions\CacheClearException If the cache can't be cleared
+     */
+    public function clearCache(): void;
+}

--- a/src/Exceptions/CacheClearException.php
+++ b/src/Exceptions/CacheClearException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roelofr\PostcodeApi\Exceptions;
+
+use GuzzleHttp\Exception\ClientException;
+use RuntimeException;
+
+/**
+ * Indicates an issue with the cache. Usually called from the cache clearing system.
+ *
+ * @license MIT
+ */
+class CacheClearException extends RuntimeException
+{
+    public const ERR_BUCKSHOT = 1;
+    public const ERR_DISABLED = 2;
+}

--- a/src/Models/AddressInformation.php
+++ b/src/Models/AddressInformation.php
@@ -25,12 +25,12 @@ class AddressInformation implements JsonSerializable
     {
         // Get data from JSON
         $fields = [
-            Arr::get($data, 'postcode'),
-            Arr::get($data, 'number'),
-            Arr::get($data, 'street'),
-            Arr::get($data, 'city'),
-            Arr::get($data, 'municipality'),
-            Arr::get($data, 'province'),
+            (string) Arr::get($data, 'postcode'),
+            (int) Arr::get($data, 'number'),
+            (string) Arr::get($data, 'street'),
+            (string) Arr::get($data, 'city'),
+            (string) Arr::get($data, 'municipality'),
+            (string) Arr::get($data, 'province'),
         ];
 
         // Validate all items are occupied

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,6 +6,7 @@ namespace Roelofr\PostcodeApi;
 
 use Roelofr\PostcodeApi\Services\PostcodeApiService;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use Roelofr\PostcodeApi\Commands\ClearPostcodeCacheCommand;
 use Roelofr\PostcodeApi\Contracts\ServiceContract;
 
 /**
@@ -32,8 +33,16 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     public function boot()
     {
+        // Add config
         $this->publishes([
             dirname(__DIR__) . '/lib/config.php' => config_path('postcode-api.php'),
         ], 'config');
+
+        // Add commands
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ClearPostcodeCacheCommand::class,
+            ]);
+        }
     }
 }

--- a/tests/Feature/CacheStorageTest.php
+++ b/tests/Feature/CacheStorageTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Roelofr\PostcodeApi\Contracts\CachedServiceContract;
+use Roelofr\PostcodeApi\Exceptions\ApiException;
+use Roelofr\PostcodeApi\Exceptions\CacheClearException;
+use Tests\TestCase;
+use Tests\Traits\HasApiResponses;
+
+/**
+ * Tests cache with a Redis cache
+ *
+ * @requires ext-redis
+ */
+class CacheStorageTest extends TestCase
+{
+    use HasApiResponses;
+
+    private const TEST_ADDRESS = [
+        'postcode' => '6545CA',
+        'number' => 29,
+        'street' => 'Waldeck Pyrmontsingel',
+        'city' => 'Nijmegen',
+        'municipality' => 'Nijmegen',
+        'province' => 'Gelderland'
+    ];
+
+    private const TEST_ADDRESS_2 = [
+        'postcode' => '6545CA',
+        'number' => 29,
+        'street' => 'Langestraat',
+        'city' => 'Almere',
+        'municipality' => 'Almere',
+        'province' => 'Flevoland'
+    ];
+
+    private const TEST_POSTCODE = self::TEST_ADDRESS['postcode'];
+    private const TEST_NUMBER = self::TEST_ADDRESS['number'];
+
+    /**
+     * Ensure cache is enabled
+     *
+     * @setUp
+     */
+    public function alwaysActivateCache(): void
+    {
+        // Make sure an app is present
+        if (!$this->app) {
+            $this->createApplication();
+        }
+
+        // Configure cache to be enabled
+        $this->app->get('config')->set([
+            'postcode-api.use-cache' => true,
+        ]);
+    }
+
+    /**
+     * Tests making a call to the API and expecting the second
+     * try to work too.
+     * @return void
+     */
+    public function testCache(): void
+    {
+        // Enable file-based cache
+        $this->app->get('config')->set([
+            'cache.default' => 'file'
+        ]);
+
+        // Flush cache
+        $this->app->get(CacheRepository::class)->flush();
+
+        // Get API
+        $instance = $this->getService(new MockHandler([
+            $this->buildJsonResponse(200, self::TEST_ADDRESS)
+        ]));
+
+        // Make request
+        $response = $instance->retrieve(self::TEST_POSTCODE, self::TEST_NUMBER);
+
+        // Quick sanity check
+        $this->assertSame(self::TEST_ADDRESS, $response->toArray());
+
+        // Run second request
+        try {
+            $response2 = $instance->retrieve(self::TEST_POSTCODE, self::TEST_NUMBER);
+            $this->assertEquals($response, $response2);
+        } catch (ApiException $e) {
+            $this->fail('Service called API, which is scheduled to fail');
+        }
+    }
+}

--- a/tests/Feature/PostcodeRetrievalTest.php
+++ b/tests/Feature/PostcodeRetrievalTest.php
@@ -135,13 +135,13 @@ class PostcodeRetrievalTest extends TestCase
     /**
      * Returns an invalid entry from the API, with exception
      * @param string $postcode
-     * @param string $number
+     * @param int $number
      * @param AddressInformation $address
      * @return array
      */
     protected function createInvalidEntry(
         string $postcode,
-        string $number,
+        int $number,
         Response $response,
         RequestException $exception
     ): array {
@@ -169,7 +169,7 @@ class PostcodeRetrievalTest extends TestCase
         return [
             $this->createValidEntry('6545CA', '29', new AddressInformation(
                 '6545CA',
-                '29',
+                29,
                 'Waldeck Pyrmontsingel',
                 'Nijmegen',
                 'Nijmegen',
@@ -177,7 +177,7 @@ class PostcodeRetrievalTest extends TestCase
             )),
             $this->createValidEntry('1021JT', '19', new AddressInformation(
                 '1021JT',
-                '19',
+                19,
                 'Hamerstraat',
                 'Amsterdam',
                 'Amsterdam',
@@ -185,7 +185,7 @@ class PostcodeRetrievalTest extends TestCase
             )),
             $this->createValidEntry('5038EA', '17', new AddressInformation(
                 '5038EA',
-                '17',
+                17,
                 'Stationsstraat',
                 'Tilburg',
                 'Tilburg',
@@ -206,7 +206,7 @@ class PostcodeRetrievalTest extends TestCase
         return [
             $this->createInvalidEntry(
                 '6545CA',
-                '299',
+                299,
                 $this->buildJsonResponse(404, ['title' => 'Resource not found']),
                 new NotFoundException('The postcode/number combination was not found', $request)
             ),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,7 @@ abstract class TestCase extends BaseTestCase
         if ($handler) {
             // Configure handler
             $httpClient = new GuzzleClient([
-                'hander' => HandlerStack::create($handler)
+                'handler' => HandlerStack::create($handler)
             ]);
 
             // Bind it
@@ -59,14 +59,8 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        // Setup default database to use sqlite :memory:
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver'   => 'sqlite',
-            'database' => ':memory:',
-            'prefix'   => '',
-        ]);
-        $app['config']->set('postcode-api', include dirname(__DIR__) . '/lib/config.php');
+        // Setup default config
+        $app->get('config')->set('postcode-api', include dirname(__DIR__) . '/lib/config.php');
     }
 
     /**

--- a/tests/Unit/AddressInformationTest.php
+++ b/tests/Unit/AddressInformationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Roelofr\PostcodeApi\Models\AddressInformation;
+use Tests\TestCase;
+
+class AddressInformationTest extends TestCase
+{
+    /**
+     * Tests the constructor and getters (should be 1:1)
+     *
+     * @param string $postcode
+     * @param int $number
+     * @param string $street
+     * @param string $city
+     * @param string $municipality
+     * @param string $province
+     * @return void
+     * @dataProvider provideConstructors
+     */
+    public function testConstructor(
+        string $postcode,
+        int $number,
+        string $street,
+        string $city,
+        string $municipality,
+        string $province
+    ): void {
+        // Address information
+        $instance = new AddressInformation($postcode, $number, $street, $city, $municipality, $province);
+
+        // Validate properties
+        $this->assertSame($postcode, $instance->getPostcode());
+        $this->assertSame($number, $instance->getNumber());
+        $this->assertSame($street, $instance->getStreet());
+        $this->assertSame($city, $instance->getCity());
+        $this->assertSame($municipality, $instance->getMunicipality());
+        $this->assertSame($province, $instance->getProvince());
+    }
+
+    public function provideConstructors(): array
+    {
+        return [
+            ['1234AB', 77, 'Dorpsstraat', 'Amsterdam', 'Amsterdam', 'Noord-Holland'],
+            ['', 0, '', '', '', ''],
+        ];
+    }
+}


### PR DESCRIPTION
Release v0.2, patch 1

### Added
- `postcode:clear-cache` command, to remove cached postcodes on a tagged cache
- `Roelofr\PostcodeApi\Contracts\CacheServiceContract` for allowing you to skip
  writing cache-clearing logic if you don't need to.
- `Roelofr\PostcodeApi\Exceptions\CacheClearException` in case cache clearing
  goes south.

### Fixed
 - Tests no longer make API calls, but use mocked responses instead

